### PR TITLE
Update ultralcd.h

### DIFF
--- a/MarlinKimbra/ultralcd.h
+++ b/MarlinKimbra/ultralcd.h
@@ -14,7 +14,7 @@
   void lcd_reset_alert_level();
   bool lcd_detected(void);
 
-#ifdef DOGLCD
+#if defined(DOGLCD) && LCD_CONTRAST >= 0
   extern int lcd_contrast;
   void lcd_setcontrast(uint8_t value);
 #endif
@@ -134,3 +134,4 @@ char *ftostr51(const float &x);
 char *ftostr52(const float &x);
 
 #endif //ULTRALCD_H
+


### PR DESCRIPTION
Enable LCD contrast function only if there is a pin decleared