### PR TITLE
improved power consumption maths and anti oozing + bug fix

### DIFF
--- a/MarlinKimbra/Configuration.h
+++ b/MarlinKimbra/Configuration.h
@@ -667,7 +667,7 @@ your extruder heater takes 2 minutes to hit the target on heating.
 // Uncomment below to enable
 //#define POWER_CONSUMPTION
 
-#define POWER_VOLTAGE      12.00    //(V)   The power supply OUT voltage
+#define POWER_VOLTAGE       12.00   //(V)   The power supply OUT voltage
 #define POWER_ZERO          2.5     //(V)   The /\V coming out from the sensor when no current flow.
 #define POWER_SENSITIVITY   0.066   //(V/A) How much increase V for 1A of increase
 #define POWER_EFFICIENCY    100.0   //(%) The power efficency of the power supply

--- a/MarlinKimbra/Configuration.h
+++ b/MarlinKimbra/Configuration.h
@@ -20,7 +20,7 @@
 // User-specified version info of this build to display in [Pronterface, etc] terminal window during
 // startup. Implementation of an idea by Prof Braino to inform user that any changes made to this
 // build by the user have been successfully uploaded into firmware.
-#define STRING_VERSION " 4.0.4"
+#define STRING_VERSION " 4.0.5"
 #define STRING_URL "reprap.org"
 #define STRING_VERSION_CONFIG_H __DATE__ " " __TIME__     // build date and time
 #define STRING_CONFIG_H_AUTHOR "(none, default config)"   // Who made the changes.

--- a/MarlinKimbra/Configuration.h
+++ b/MarlinKimbra/Configuration.h
@@ -667,10 +667,10 @@ your extruder heater takes 2 minutes to hit the target on heating.
 // Uncomment below to enable
 //#define POWER_CONSUMPTION
 
-#define POWER_VOLTAGE			13.56     //(V) The power supply OUT voltage
+#define POWER_VOLTAGE			12.00     //(V) The power supply OUT voltage
 #define POWER_ZERO			2.54459   //(V) The /\V coming out from the sensor when no current flow.
 #define POWER_SENSITIVITY		0.066     //(V/A) How much increase V for 1A of increase
-#define POWER_OFFSET			0.015     //(%) Help to get 0A when no load is connected.
+#define POWER_OFFSET			0.015     //(A) Help to get 0A when no load is connected.
 #define POWER_ERROR			3.0       //(%) Ammortize measure error.
 #define POWER_EFFICIENCY		100.0     //(%) The power efficency of the power supply
 

--- a/MarlinKimbra/Configuration.h
+++ b/MarlinKimbra/Configuration.h
@@ -667,10 +667,12 @@ your extruder heater takes 2 minutes to hit the target on heating.
 // Uncomment below to enable
 //#define POWER_CONSUMPTION
 
-#define POWER_VOLTAGE       12.00   //(V)   The power supply OUT voltage
-#define POWER_ZERO          2.5     //(V)   The /\V coming out from the sensor when no current flow.
-#define POWER_SENSITIVITY   0.066   //(V/A) How much increase V for 1A of increase
-#define POWER_EFFICIENCY    100.0   //(%) The power efficency of the power supply
+#define POWER_VOLTAGE			13.56     //(V) The power supply OUT voltage
+#define POWER_ZERO			2.54459   //(V) The /\V coming out from the sensor when no current flow.
+#define POWER_SENSITIVITY		0.066     //(V/A) How much increase V for 1A of increase
+#define POWER_OFFSET			0.015     //(%) Help to get 0A when no load is connected.
+#define POWER_ERROR			3.0       //(%) Ammortize measure error.
+#define POWER_EFFICIENCY		100.0     //(%) The power efficency of the power supply
 
 //When using an LCD, uncomment the line below to display the Power consumption sensor data on the last line instead of status.  Status will appear for 5 sec.
 //#define POWER_CONSUMPTION_LCD_DISPLAY

--- a/MarlinKimbra/Configuration_adv.h
+++ b/MarlinKimbra/Configuration_adv.h
@@ -46,16 +46,21 @@
 
 //  extruder idle oozing prevention
 //if the extruder motor is idle for more than SECONDS, and the temperature over MINTEMP, some filament is retracted. The filament retracted is re-added before the next extrusion
+//or when the target temperature is less than EXTRUDE_MINTEMP and the actual temperature is greater than IDLE_OOZING_MINTEMP and less than IDLE_OOZING_FEEDRATE
 //#define IDLE_OOZING_PREVENT
-#define IDLE_OOZING_MINTEMP          170
-#define IDLE_OOZING_FEEDRATE          45    //default feedrate for retracting (mm/s)
+#define IDLE_OOZING_MINTEMP           EXTRUDE_MINTEMP+5
+#define IDLE_OOZING_FEEDRATE          IDLE_OOZING_MINTEMP+5     //default feedrate for retracting (mm/s)
 #define IDLE_OOZING_SECONDS           10
-#define IDLE_OOZING_LENGTH            15    //default retract length (positive mm)
-#define IDLE_OOZING_RECOVER_LENGTH     0    //default additional recover length (mm, added to retract length when recovering)
-#define IDLE_OOZING_RECOVER_FEEDRATE  50    //default feedrate for recovering from retraction (mm/s)
+#define IDLE_OOZING_LENGTH            15                        //default retract length (positive mm)
+#define IDLE_OOZING_RECOVER_LENGTH     0                        //default additional recover length (mm, added to retract length when recovering)
+#define IDLE_OOZING_RECOVER_FEEDRATE  50                        //default feedrate for recovering from retraction (mm/s)
 
 #if defined(IDLE_OOZING_PREVENT) && IDLE_OOZING_MINTEMP < EXTRUDE_MINTEMP
   #error IDLE_OOZING_MINTEMP have to be greater than EXTRUDE_MINTEMP
+#endif
+
+#if defined(IDLE_OOZING_PREVENT) && IDLE_OOZING_MAXTEMP < IDLE_OOZING_MINTEMP
+  #error IDLE_OOZING_MAXTEMP have to be greater than IDLE_OOZING_MINTEMP
 #endif
 //  extruder run-out prevention.
 //if the machine is idle, and the temperature over MINTEMP, every couple of SECONDS some filament is extruded

--- a/MarlinKimbra/Configuration_adv.h
+++ b/MarlinKimbra/Configuration_adv.h
@@ -48,8 +48,9 @@
 //if the extruder motor is idle for more than SECONDS, and the temperature over MINTEMP, some filament is retracted. The filament retracted is re-added before the next extrusion
 //or when the target temperature is less than EXTRUDE_MINTEMP and the actual temperature is greater than IDLE_OOZING_MINTEMP and less than IDLE_OOZING_FEEDRATE
 //#define IDLE_OOZING_PREVENT
-#define IDLE_OOZING_MINTEMP           EXTRUDE_MINTEMP+5
-#define IDLE_OOZING_FEEDRATE          IDLE_OOZING_MINTEMP+5     //default feedrate for retracting (mm/s)
+#define IDLE_OOZING_MINTEMP          EXTRUDE_MINTEMP+5
+#define IDLE_OOZING_MAXTEMP          IDLE_OOZING_MINTEMP+5
+#define IDLE_OOZING_FEEDRATE         45	                        //default feedrate for retracting (mm/s)
 #define IDLE_OOZING_SECONDS           10
 #define IDLE_OOZING_LENGTH            15                        //default retract length (positive mm)
 #define IDLE_OOZING_RECOVER_LENGTH     0                        //default additional recover length (mm, added to retract length when recovering)

--- a/MarlinKimbra/Marlin.h
+++ b/MarlinKimbra/Marlin.h
@@ -309,7 +309,7 @@ extern unsigned char fanSpeedSoftPwm;
 #endif
 
 #if (defined(POWER_CONSUMPTION) && defined(POWER_CONSUMPTION_PIN) && POWER_CONSUMPTION_PIN >= 0)
-  extern unsigned int power_consumption_meas;   //holds the power consumption as accurately measured
+  extern float power_consumption_meas;          //holds the power consumption as accurately measured
   extern unsigned long power_consumption_hour;  //holds the power consumption per hour as accurately measured
 #endif
 

--- a/MarlinKimbra/Marlin_main.cpp
+++ b/MarlinKimbra/Marlin_main.cpp
@@ -413,7 +413,7 @@ uint8_t debugLevel = 0;
 #endif
 
 #if defined(POWER_CONSUMPTION) && defined(POWER_CONSUMPTION_PIN) && POWER_CONSUMPTION_PIN >= 0
-  unsigned int power_consumption_meas = 0;
+  float power_consumption_meas = 0;
   unsigned long power_consumption_hour = 0.0;
 #endif
 
@@ -6563,16 +6563,26 @@ void manage_inactivity(bool ignore_stepper_queue/*=false*/) //default argument s
   #endif
 
   #ifdef IDLE_OOZING_PREVENT
-    if (!debugDryrun() && !axis_is_moving && (millis() - axis_last_activity) >  IDLE_OOZING_SECONDS * 1000 && degHotend(active_extruder) > IDLE_OOZING_MINTEMP) {
-      #ifdef FILAMENTCHANGEENABLE
+    if (degHotend(active_extruder) > IDLE_OOZING_MINTEMP && !debugDryrun())
+	{
+	  #ifdef FILAMENTCHANGEENABLE
         if (!filament_changing)
       #endif
-      IDLE_OOZING_retract(true);
-    }
+      {
+	    if(degHotend(active_extruder) < IDLE_OOZING_MAXTEMP && degTargetHotend(active_extruder) < IDLE_OOZING_MINTEMP)
+		{
+		  IDLE_OOZING_retract(false);
+	    }
+	    else if(!axis_is_moving && (millis() - axis_last_activity) >  IDLE_OOZING_SECONDS*1000)
+		{
+		  IDLE_OOZING_retract(true);
+		}
+	  }
+	}
   #endif
 
   #ifdef EXTRUDER_RUNOUT_PREVENT
-    if (!debugDryrun() && !axis_is_moving && (millis() - axis_last_activity) >  EXTRUDER_RUNOUT_SECONDS * 1000 && degHotend(active_extruder) > EXTRUDER_RUNOUT_MINTEMP)
+    if (degHotend(active_extruder) > EXTRUDER_RUNOUT_MINTEMP && !debugDryrun() && !axis_is_moving && (millis() - axis_last_activity) >  EXTRUDER_RUNOUT_SECONDS * 1000)
     {
       #ifdef FILAMENTCHANGEENABLE
         if (!filament_changing)

--- a/MarlinKimbra/dogm_lcd_implementation.h
+++ b/MarlinKimbra/dogm_lcd_implementation.h
@@ -279,7 +279,7 @@ static void lcd_implementation_status_screen() {
       #endif
       {
         lcd_printPGM(PSTR("P:"));
-        u8g.print(itostr3(power_consumption_meas));
+        u8g.print(ftostr31(power_consumption_meas));
         lcd_printPGM(PSTR("W C:"));
         u8g.print(ltostr7(power_consumption_hour));
         lcd_printPGM(PSTR("Wh"));

--- a/MarlinKimbra/dogm_lcd_implementation.h
+++ b/MarlinKimbra/dogm_lcd_implementation.h
@@ -267,7 +267,7 @@ static void lcd_implementation_status_screen() {
   // Status line
   u8g.setFont(FONT_STATUSMENU);
   u8g.setPrintPos(0,63);
-  #if defined(FILAMENT_SENSOR) && defined(FILWIDTH_PIN) && (FILWIDTH_PIN >= 0) && defined(FILAMENT_LCD_DISPLAY) || (defined(POWER_CONSUMPTION) && defined(POWER_CONSUMPTION_PIN) && (POWER_CONSUMPTION_PIN >= 0) && defined(POWER_CONSUMPTION_LCD_DISPLAY)
+  #if defined(FILAMENT_SENSOR) && defined(FILWIDTH_PIN) && (FILWIDTH_PIN >= 0) && defined(FILAMENT_LCD_DISPLAY) || defined(POWER_CONSUMPTION) && defined(POWER_CONSUMPTION_PIN) && (POWER_CONSUMPTION_PIN >= 0) && defined(POWER_CONSUMPTION_LCD_DISPLAY)
     if (millis() < message_millis + 5000) {  //Display both Status message line and Filament display on the last line
       u8g.print(lcd_status_message);
     }

--- a/MarlinKimbra/temperature.h
+++ b/MarlinKimbra/temperature.h
@@ -40,6 +40,7 @@ void manage_heater(); //it is critical that this is called periodically.
 
 #if (defined(POWER_CONSUMPTION) && defined(POWER_CONSUMPTION_PIN) && POWER_CONSUMPTION_PIN >= 0)
   // For converting raw Power Consumption to watt
+  float analog2current();
   float analog2power();
 #endif
 

--- a/MarlinKimbra/ultralcd.cpp
+++ b/MarlinKimbra/ultralcd.cpp
@@ -690,11 +690,10 @@ void config_lcd_level_bed()
 void lcd_level_bed()
 {
   if(ChangeScreen) {
-    lcd.clear();
     switch(pageShowInfo) {
       case 0:
         {
-          lcd.setCursor(0, 1);
+          u8g.setPrintPos(0, 1);
           lcd_printPGM(PSTR(MSG_LP_INTRO));
           currentMenu = lcd_level_bed;
           ChangeScreen=false;
@@ -702,7 +701,7 @@ void lcd_level_bed()
       break;
       case 1:
         {
-          lcd.setCursor(0, 1);
+          u8g.setPrintPos(0, 1);
           lcd_printPGM(PSTR(MSG_LP_1));
           currentMenu = lcd_level_bed;
           ChangeScreen=false;
@@ -710,7 +709,7 @@ void lcd_level_bed()
       break;
       case 2:
         {
-          lcd.setCursor(0, 1);
+          u8g.setPrintPos(0, 1);
           lcd_printPGM(PSTR(MSG_LP_2));
               currentMenu = lcd_level_bed;
            ChangeScreen=false;
@@ -718,7 +717,7 @@ void lcd_level_bed()
       break;
       case 3:
         {  
-          lcd.setCursor(0, 1);
+          u8g.setPrintPos(0, 1);
           lcd_printPGM(PSTR(MSG_LP_3));
           currentMenu = lcd_level_bed;
           ChangeScreen=false;
@@ -726,7 +725,7 @@ void lcd_level_bed()
       break;        
       case 4:
         {
-          lcd.setCursor(0, 1);
+          u8g.setPrintPos(0, 1);
           lcd_printPGM(PSTR(MSG_LP_4));
           currentMenu = lcd_level_bed;
           ChangeScreen=false; 
@@ -734,7 +733,7 @@ void lcd_level_bed()
       break;
       case 5:
         {
-          lcd.setCursor(0, 1);
+          u8g.setPrintPos(0, 1);
           lcd_printPGM(PSTR(MSG_LP_5));
           currentMenu = lcd_level_bed;
           ChangeScreen=false;
@@ -742,12 +741,12 @@ void lcd_level_bed()
       break;
       case 6:
         {
-          lcd.setCursor(2, 2);
+          u8g.setPrintPos(2, 2);
           lcd_printPGM(PSTR(MSG_LP_6));
           ChangeScreen=false;
           delay(1200);
           encoderPosition = 0;
-          lcd.clear();
+          lcd_implementation_clear();
           currentMenu = lcd_status_screen;
           lcd_status_screen();
           pageShowInfo=0;

--- a/MarlinKimbra/ultralcd_implementation_hitachi_HD44780.h
+++ b/MarlinKimbra/ultralcd_implementation_hitachi_HD44780.h
@@ -629,7 +629,7 @@ static void lcd_implementation_status_screen() {
       #endif
       {
         lcd_printPGM(PSTR("P:"));
-        lcd.print(itostr3(power_consumption_meas));
+        lcd.print(ftostr31(power_consumption_meas));
         lcd_printPGM(PSTR("W C:"));
         lcd.print(ltostr7(power_consumption_hour));
         lcd_printPGM(PSTR("Wh"));

--- a/README.md
+++ b/README.md
@@ -38,4 +38,4 @@ The current MarlinKimbra dev team consists of:
   
 
 More features have been added by:
-  - 
+ - simone97 (https://github.com/simone97)


### PR DESCRIPTION
Ho sistemato un po le formule per il sensore di corrente, dato che oggi mi è arrivato ed ho avuto modo di testarlo.
Dopo mezza giornata di lavoro ora ottengo un valore con un errore dell +-1%  rispetto a quello misurato con un tester affidabile.
Ho inoltre ho levato il filtro sull'oversampling che impediva di ottenere valori decenti con cambi veloci di corrente.
Per quanto riguarda l'oozing, ora il filamento viene se retratto in precedenza viene riestruso prima che il nozzo si raffreddi completamente.
Questo evita (a patto che uno attenda che il nozzle si raffreddi) che il filamento a forza di retrazioni venga completamente espulso.
Ad esempio:
Il filamento viene retratto perchè superata la temperatura e il tempo di idle, poi lascio raffreddare il nozzle.
Una volta freddo spengo la stampante, riaccendo, e riscaldo nuovamente. Il filamento verrà retratto ancora e questo dopo un po di volte porta alla completa espulsione del filamento.

Altra piccola cosetta:
Nel file ultralcd.cpp
l'oggetto lcd non è definita quindi non è possibile usare lcd. e infatti da anche errore di compilazione.

Spero ti possa essere di aiuto,
Saluti
Simone