### PR TITLE
Power Consumption LCD Update + code clean

### DIFF
--- a/MarlinKimbra/Conditionals.h
+++ b/MarlinKimbra/Conditionals.h
@@ -436,6 +436,12 @@
   #if HAS_FAN
     #define WRITE_FAN(v) WRITE(FAN_PIN, v)
   #endif
+  
+  /**
+   * Shorthand for sensor test for ultralcd.cpp, dogm_lcd_implementation.h, ultralcd_implementation_hitachi_HD44780.h
+   */
+   #define HAS_LCD_FILAMENT_SENSOR (HAS_FILAMENT_SENSOR && defined(FILAMENT_LCD_DISPLAY))
+   #define HAS_LCD_POWER_SENSOR (HAS_POWER_CONSUMPTION_SENSOR && defined(POWER_CONSUMPTION_LCD_DISPLAY))
 
 #endif //CONFIGURATION_LCD
 #endif //CONDITIONALS_H

--- a/MarlinKimbra/ConfigurationStore.cpp
+++ b/MarlinKimbra/ConfigurationStore.cpp
@@ -41,7 +41,7 @@ void _EEPROM_readData(int &pos, uint8_t* value, uint8_t size) {
 // wrong data being written to the variables.
 // ALSO:  always make sure the variables in the Store and retrieve sections are in the same order.
 
-#define EEPROM_VERSION "V17"
+#define EEPROM_VERSION "V18"
 
 #ifdef EEPROM_SETTINGS
 void Config_StoreSettings() {
@@ -131,6 +131,10 @@ void Config_StoreSettings() {
   
   #ifdef IDLE_OOZING_PREVENT
     EEPROM_WRITE_VAR(i, idleoozing_enabled);
+  #endif
+  
+  #if defined(POWER_CONSUMPTION) && defined(STORE_CONSUMPTION)
+    EEPROM_WRITE_VAR(i, power_consumption_hour);
   #endif
 
   int storageSize = i;
@@ -254,6 +258,10 @@ void Config_RetrieveSettings()
 
     #ifdef IDLE_OOZING_PREVENT
       EEPROM_READ_VAR(i, idleoozing_enabled);
+    #endif
+	
+	#if defined(POWER_CONSUMPTION) && defined(STORE_CONSUMPTION)
+      EEPROM_READ_VAR(i, power_consumption_hour);
     #endif
 
     // Call updatePID (similar to when we have processed M301)
@@ -399,6 +407,10 @@ void Config_ResetDefault()
 
   #ifdef IDLE_OOZING_PREVENT
     idleoozing_enabled = true;
+  #endif
+  
+  #if defined(POWER_CONSUMPTION) && defined(STORE_CONSUMPTION)
+    power_consumption_hour = 0;
   #endif
 
   SERIAL_ECHO_START;

--- a/MarlinKimbra/Marlin.h
+++ b/MarlinKimbra/Marlin.h
@@ -307,6 +307,8 @@ extern int fanSpeed;
 #if HAS_POWER_CONSUMPTION_SENSOR
   extern float power_consumption_meas;          //holds the power consumption as accurately measured
   extern unsigned long power_consumption_hour;  //holds the power consumption per hour as accurately measured
+  extern unsigned long startpower;
+  extern unsigned long stoppower;
 #endif
 
 #ifdef IDLE_OOZING_PREVENT

--- a/MarlinKimbra/dogm_lcd_implementation.h
+++ b/MarlinKimbra/dogm_lcd_implementation.h
@@ -280,10 +280,23 @@ static void lcd_implementation_status_screen() {
 
     u8g.setPrintPos(80,48);
     if (starttime != 0) {
-      uint16_t time = (millis() - starttime) / 60000;
-      lcd_print(itostr2(time/60));
-      lcd_print(':');
-      lcd_print(itostr2(time%60));
+      #if HAS_LCD_POWER_SENSOR
+        if (millis() < print_millis + 1000) {
+          uint16_t time = (millis() - starttime) / 60000;
+          lcd_print(itostr2(time/60));
+          lcd_print(':');
+          lcd_print(itostr2(time%60));
+        }
+        else {
+          lcd_print(itostr4(power_consumption_hour-startpower));
+          lcd_print('Wh');
+        }
+      #else
+        uint16_t time = (millis() - starttime) / 60000;
+        lcd_print(itostr2(time/60));
+        lcd_print(':');
+        lcd_print(itostr2(time%60));
+      #endif
     }
     else {
       lcd_printPGM(PSTR("--:--"));
@@ -358,12 +371,13 @@ static void lcd_implementation_status_screen() {
   #else
   u8g.setPrintPos(0,63);
   #endif
-  #if HAS_FILAMENT_SENSOR || HAS_POWER_CONSUMPTION_SENSOR
+  
+  #if HAS_LCD_FILAMENT_SENSOR || HAS_LCD_POWER_SENSOR
     if (millis() < message_millis + 5000) {  //Display both Status message line and Filament display on the last line
       lcd_print(lcd_status_message);
     }
-    #if HAS_POWER_CONSUMPTION_SENSOR && defined(POWER_CONSUMPTION_LCD_DISPLAY)
-      #if HAS_FILAMENT_SENSOR && defined(FILAMENT_LCD_DISPLAY)
+    #if HAS_LCD_POWER_SENSOR
+      #if HAS_LCD_FILAMENT_SENSOR
         else if (millis() < message_millis + 10000)
       #else
         else
@@ -376,7 +390,7 @@ static void lcd_implementation_status_screen() {
         lcd_printPGM(PSTR("Wh"));
       }
     #endif
-    #if HAS_FILAMENT_SENSOR && defined(FILAMENT_LCD_DISPLAY)
+    #if HAS_LCD_FILAMENT_SENSOR
       else {
         lcd_printPGM(PSTR("D:"));
         lcd_print(ftostr12ns(filament_width_meas));

--- a/MarlinKimbra/ultralcd.cpp
+++ b/MarlinKimbra/ultralcd.cpp
@@ -33,8 +33,12 @@ int gumPreheatFanSpeed;
 const long baudrates[] = {9600,14400,19200,28800,38400,56000,115200,250000};
 int baudrate_position = -1;
 
-#if (HAS_FILAMENT_SENSOR && defined(FILAMENT_LCD_DISPLAY)) || (HAS_POWER_CONSUMPTION_SENSOR && defined(POWER_CONSUMPTION_LCD_DISPLAY))
+#if HAS_LCD_FILAMENT_SENSOR || HAS_LCD_POWER_SENSOR
   unsigned long message_millis = 0;
+#endif
+
+#if HAS_LCD_POWER_SENSOR
+  unsigned long print_millis = 0;
 #endif
 
 /* !Configuration settings */
@@ -314,6 +318,21 @@ static void lcd_status_screen()
     lcd_implementation_status_screen();
     lcd_status_update_delay = 10;   /* redraw the main screen every second. This is easier then trying keep track of all things that change on the screen */
   }
+  
+  #if HAS_LCD_POWER_SENSOR
+    if (millis() > print_millis + 2000) print_millis = millis();
+  #endif
+  
+  #if HAS_LCD_FILAMENT_SENSOR || HAS_LCD_POWER_SENSOR
+    #if HAS_LCD_FILAMENT_SENSOR && HAS_LCD_POWER_SENSOR
+      if (millis() > message_millis + 15000)
+    #else
+     if (millis() > message_millis + 10000)
+    #endif
+    {
+      message_millis = millis();
+    }
+  #endif
 
 #ifdef ULTIPANEL
 
@@ -343,16 +362,6 @@ static void lcd_status_screen()
           currentMenu == lcd_status_screen
         #endif
       );
-      #if (HAS_FILAMENT_SENSOR && defined(FILAMENT_LCD_DISPLAY)) || (HAS_POWER_CONSUMPTION_SENSOR && defined(POWER_CONSUMPTION_LCD_DISPLAY))
-        #if (HAS_FILAMENT_SENSOR && defined(FILAMENT_LCD_DISPLAY)) && (HAS_POWER_CONSUMPTION_SENSOR && defined(POWER_CONSUMPTION_LCD_DISPLAY))
-          if (millis() > message_millis + 15000)
-        #else
-          if (millis() > message_millis + 10000)
-        #endif
-          {
-            message_millis = millis();
-          }
-      #endif
     }
 
 #ifdef ULTIPANEL_FEEDMULTIPLY
@@ -1618,10 +1627,6 @@ void lcd_finishstatus(bool persist=false) {
     #endif
   #endif
   lcdDrawUpdate = 2;
-
-  #ifdef FILAMENT_LCD_DISPLAY
-    message_millis = millis();  //get status message to show up for a while
-  #endif
 }
 
 #if defined(LCD_PROGRESS_BAR) && PROGRESS_MSG_EXPIRE > 0

--- a/MarlinKimbra/ultralcd_implementation_hitachi_HD44780.h
+++ b/MarlinKimbra/ultralcd_implementation_hitachi_HD44780.h
@@ -586,13 +586,27 @@ static void lcd_implementation_status_screen()
       #endif //SDSUPPORT
     #endif //LCD_WIDTH > 19
     lcd.setCursor(LCD_WIDTH - 6, 2);
-    lcd.print(LCD_STR_CLOCK[0]);
     if(starttime != 0)
     {
-      uint16_t time = millis()/60000 - starttime/60000;
-      lcd.print(itostr2(time/60));
-      lcd.print(':');
-      lcd.print(itostr2(time%60));
+      #if HAS_LCD_POWER_SENSOR
+        if (millis() < print_millis + 1000) {
+          lcd.print(LCD_STR_CLOCK[0]);
+          uint16_t time = millis()/60000 - starttime/60000;
+          lcd.print(itostr2(time/60));
+          lcd.print(':');
+          lcd.print(itostr2(time%60));
+        }
+        else {
+          lcd.print(itostr4(power_consumption_hour-startpower));
+          lcd.print('Wh');
+        }
+      #else
+        lcd.print(LCD_STR_CLOCK[0]);
+        uint16_t time = millis()/60000 - starttime/60000;
+        lcd.print(itostr2(time/60));
+        lcd.print(':');
+        lcd.print(itostr2(time%60));
+      #endif
     }
     else {
       lcd_printPGM(PSTR("--:--"));
@@ -627,12 +641,12 @@ static void lcd_implementation_status_screen()
   #endif //LCD_PROGRESS_BAR
 
   //Display both Status message line and Filament display on the last line
-  #if (HAS_FILAMENT_SENSOR && defined(FILAMENT_LCD_DISPLAY)) || (HAS_POWER_CONSUMPTION_SENSOR && defined(POWER_CONSUMPTION_LCD_DISPLAY))
+  #if HAS_LCD_FILAMENT_SENSOR || HAS_LCD_POWER_SENSOR
     if (millis() < message_millis + 5000) {  //Display both Status message line and Filament display on the last line
       lcd_print(lcd_status_message);
     }
-    #if HAS_POWER_CONSUMPTION_SENSOR && defined(POWER_CONSUMPTION_LCD_DISPLAY)
-      #if HAS_FILAMENT_SENSOR && defined(FILAMENT_LCD_DISPLAY)
+    #if HAS_LCD_POWER_SENSOR
+      #if HAS_LCD_FILAMENT_SENSOR
         else if (millis() < message_millis + 10000)
       #else
         else
@@ -645,7 +659,7 @@ static void lcd_implementation_status_screen()
         lcd_printPGM(PSTR("Wh"));
       }
     #endif
-    #if HAS_FILAMENT_SENSOR && defined(FILAMENT_LCD_DISPLAY)
+    #if HAS_LCD_FILAMENT_SENSOR
       else {
         lcd_printPGM(PSTR("D:"));
         lcd.print(ftostr12ns(filament_width_meas));


### PR DESCRIPTION
* Aggiunta la possibilità di salvare il consumo energetico nella EEPROM
* Se è definito POWER_CONSUMPTION_LCD_DISPLAY alla fine della stampa di un oggetto oltre al tempo della stampa sarà mostrato anche il consumo energetico utilizzato.
* Se è definito POWER_CONSUMPTION_LCD_DISPLAY ogni 1 secondo si alterna sull LCD il tempo di stampa e il consumo energetico
* Fix alternanza ogni 5sec di messaggio di stato, consumo energetico e sensore filamento.
* Aggiunte macro in Conditional.h