### PR TITLE
Fixed X_MIN_PIN and X_MAX_PIN for DUAL_X_CARRIAGE

### DIFF
--- a/MK/module/MK_Main.cpp
+++ b/MK/module/MK_Main.cpp
@@ -1176,7 +1176,7 @@ static void update_software_endstops(AxisEnum axis) {
       }
       else if (dual_x_carriage_mode == DXC_DUPLICATION_MODE) {
         sw_endstop_min[X_AXIS] = base_min_pos(X_AXIS) + offs;
-        sw_endstop_max[X_AXIS] = min(base_max_pos(X_AXIS), dual_max_x - duplicate_extruder_x_offset) + offs;
+        sw_endstop_max[X_AXIS] = min(base_max_pos(X_AXIS), dual_max_x - duplicate_hotend_x_offset) + offs;
         return;
       }
     }

--- a/MK/module/mechanics.h
+++ b/MK/module/mechanics.h
@@ -33,6 +33,7 @@
   #define MECH_DELTA       3
   #define MECH_SCARA       4
 
-  #define MECH(mech)  (MECHANISM == MECH_##mech)
+#define MECH(mech)    (MECHANISM == MECH_##mech)
+#define NOMECH(mech)  (MECHANISM != MECH_##mech)
 
 #endif

--- a/MK/module/pins.h
+++ b/MK/module/pins.h
@@ -231,13 +231,16 @@
 /****************************************************************************************/
 
 
-#if X_HOME_DIR > 0    // Home X to MAX
-  #undef X_MIN_PIN
-  #define X_MIN_PIN -1
-#elif X_HOME_DIR < 0  // Home X to MIN
-  #undef X_MAX_PIN
-  #define X_MAX_PIN -1
-#endif //X_HOME_DIR > 0
+#if DISABLED(DUAL_X_CARRIAGE)
+	#if X_HOME_DIR > 0    // Home X to MAX
+		#undef X_MIN_PIN
+		#define X_MIN_PIN -1
+	#elif X_HOME_DIR < 0  // Home X to MIN
+		#undef X_MAX_PIN
+		#define X_MAX_PIN -1
+	#endif //X_HOME_DIR > 0
+#endif.
+
 
 #if Y_HOME_DIR > 0    // Home Y to MAX
   #undef Y_MIN_PIN

--- a/MK/module/sanitycheck.h
+++ b/MK/module/sanitycheck.h
@@ -1624,8 +1624,8 @@
         #if Z_ENDSTOP_SERVO_NR < 0
           #error DEPENDENCY ERROR: You must have Z_ENDSTOP_SERVO_NR set to at least 0 or above to use Z_PROBE_ENDSTOP.
         #endif
-        #if DISABLED(SERVO_ENDSTOP_ANGLES)
-          #error DEPENDENCY ERROR: You must have SERVO_ENDSTOP_ANGLES EXIST for Z Extend and Retract to use Z_PROBE_ENDSTOP.
+         #if DISABLED(Z_ENDSTOP_SERVO_ANGLES)
+         #error DEPENDENCY ERROR: You must have Z_ENDSTOP_SERVO_ANGLES EXIST for Z Extend and Retract to use Z_PROBE_ENDSTOP.
         #endif
       #endif
     #endif


### PR DESCRIPTION
If defined DUAL_X_CARRIAGE it's necessary to have X_MAX_PIN for homing the extruder.
To check it if it's ok